### PR TITLE
Fix issue #6 + use installation context in templates

### DIFF
--- a/templates/app.ini
+++ b/templates/app.ini
@@ -1,12 +1,12 @@
 ; App name that shows on every page title
 APP_NAME = {{ conf.title }}
 ; Change it if you run locally
-RUN_USER = gogs
+RUN_USER = {{ user }}
 ; Either "dev", "prod" or "test", default is "dev"
 RUN_MODE = {{ conf.run_mode }}
 
 [repository]
-ROOT = /opt/gogs/repositories
+ROOT = {{ home }}/repositories
 SCRIPT_TYPE = bash
 ; Default ANSI charset
 ANSI_CHARSET = 
@@ -34,7 +34,7 @@ SSH_PORT = {{ conf.ssh_port }}
 ; Port number builtin SSH server listens on
 SSH_LISTEN_PORT = %(SSH_PORT)s
 ; Root path of SSH directory, default is '~/.ssh', but you have to use '/home/git/.ssh'.
-SSH_ROOT_PATH = /opt/gogs/.ssh 
+SSH_ROOT_PATH = {{ home }}/.ssh 
 ; Directory to create temporary files when test publick key using ssh-keygen,
 ; default is system temporary directory.
 SSH_KEY_TEST_PATH =
@@ -58,7 +58,7 @@ DISABLE_ROUTER_LOG = false
 ; default is the path where Gogs is executed
 STATIC_ROOT_PATH =
 ; Default path for App data
-APP_DATA_PATH = /opt/gogs/data
+APP_DATA_PATH = {{ home }}/data
 ; Application level GZIP support
 ENABLE_GZIP = false
 ; Landing page for non-logged users, can be "home" or "explore"
@@ -97,7 +97,7 @@ COOKIE_REMEMBER_NAME = gogs_incredible
 REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
 
 [log]
-ROOT_PATH = /opt/gogs/logs
+ROOT_PATH = {{ home }}/logs
 ; Either "console", "file", "conn", "smtp" or "database", default is "console"
 ; Use comma to separate multiple modes, e.g. "console, file"
 MODE = file

--- a/templates/gogs.service
+++ b/templates/gogs.service
@@ -15,12 +15,12 @@ After=network.target
 #LimitMEMLOCK=infinity
 #LimitNOFILE=65535
 Type=simple
-User=gogs
-Group=gogs
-WorkingDirectory=/opt/gogs
-ExecStart=/opt/gogs/gogs web --config /opt/gogs/custom/conf/app.ini
+User={{ user }}
+Group={{ group }}
+WorkingDirectory={{ home }}
+ExecStart={{ home }}/gogs web --config {{ home }}/custom/conf/app.ini
 Restart=always
-Environment=USER=gogs HOME=/opt/gogs
+Environment=USER={{ user }} HOME={{ home }}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/gogs.service
+++ b/templates/gogs.service
@@ -20,7 +20,7 @@ Group=gogs
 WorkingDirectory=/opt/gogs
 ExecStart=/opt/gogs/gogs web --config /opt/gogs/custom/conf/app.ini
 Restart=always
-Environment=USER=gogs HOME=/opt/gogs/.ssh
+Environment=USER=gogs HOME=/opt/gogs
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/upstart
+++ b/templates/upstart
@@ -4,12 +4,12 @@ start on runlevel [2345]
 stop on runlevel [!2345]
 respawn
 
-setuid gogs
-setgid gogs
+setuid {{ user }}
+setgid {{ group }}
 
-chdir /opt/gogs
-env HOME=/opt/gogs
-env USER=gogs
+chdir {{ home }}
+env HOME={{ home }}
+env USER={{ user }}
 
-exec /opt/gogs/gogs web --config /opt/gogs/custom/conf/app.ini
+exec {{ home }}/gogs web --config {{ home }}/custom/conf/app.ini
 

--- a/templates/upstart
+++ b/templates/upstart
@@ -8,7 +8,7 @@ setuid gogs
 setgid gogs
 
 chdir /opt/gogs
-env HOME=/opt/gogs/.ssh
+env HOME=/opt/gogs
 env USER=gogs
 
 exec /opt/gogs/gogs web --config /opt/gogs/custom/conf/app.ini


### PR DESCRIPTION
This PR first fixes the issue #6:
`HOME` is no defined at `/opt/gogs`

and it defines an installation context (_home, user and group_) and use it in templates.